### PR TITLE
Coordinate app / lib bundling.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,12 +11,25 @@ var browserify = require('browserify');
 var babelify = require('babelify');
 var source = require('vinyl-source-stream');
 
-gulp.task('build-js', function() {
-    return browserify('./src/Arc.js')
-        .transform(babelify)
-        .bundle()
-        .pipe(source('bundle.js'))
-        .pipe(gulp.dest('./dist'));
-});
+gulp.task('bundle-libs', bundle_libs);
+function bundle_libs () {
+  return browserify()
+    .require('react', {expose: 'react'})
+    .bundle()
+    .pipe(source('libs.js'))
+    .pipe(gulp.dest('./dist'));
+}
 
-gulp.task('build', ['build-js']);
+gulp.task('bundle-app', bundle_app);
+function bundle_app () {
+  return browserify('./src/Arc.js', {
+    standalone: "react_svg",
+  })
+    .transform(babelify)
+    .external('react')
+    .bundle()
+    .pipe(source('bundle.js'))
+    .pipe(gulp.dest('./dist'));
+}
+
+gulp.task('build', ['bundle-libs', 'bundle-app']);

--- a/src/Arc.js
+++ b/src/Arc.js
@@ -1,3 +1,7 @@
+var React = require('react');
+var PropTypes = React.PropTypes;
+var Component = React.Component;
+
 class Arc extends Component {
     static propTypes = {
         radius: PropTypes.number,


### PR DESCRIPTION
Per [StackOverflow question](http://stackoverflow.com/q/36137169/1034448). I understand the whole picture now. This PR gives an example of one way to accomplish the kind of thing you want. Key concepts:
- Create a lib bundle that "exports" a `require()` call that exposes `react`.
- Create an app bundle that exposes your component via `standalone`. This makes it so that it can be `require()`'d via Node's module system, although for that case you may want to `derequire` it. Also, in the browser, it makes it available as a global, `window.react_svg`.
- Exclude React from the app bundle with `.external("react")`. The `require("react")` call will still be in the bundle. This is coordinated with the lib bundle that creates a `require()` that'll make that work.

So for example this would work:

``` html
<script src="./libs.js"></script>

<script src="./bundle.js"></script>

<script>
var el = require("react").createElement(window.react_svg.default);
console.log(el);
</script>
```
